### PR TITLE
Allow negative in clipposn

### DIFF
--- a/manialink_v3.xsd
+++ b/manialink_v3.xsd
@@ -489,7 +489,7 @@
             <xs:attributeGroup ref="basicAttrib" />
             <xs:attribute name="size" type="type_float2positive" use="optional" />
             <xs:attribute name="clip" type="type_bool" use="optional" />
-            <xs:attribute name="clipposn" type="type_float2positive" use="optional" />
+            <xs:attribute name="clipposn" type="type_float2" use="optional" />
             <xs:attribute name="clipsizen" type="type_float2positive" use="optional" />
             <xs:attribute name="scroll" type="type_bool" use="optional" />
             <xs:attribute name="scrollmax" type="type_float2positive" use="optional" />

--- a/manialink_v3_ns.xsd
+++ b/manialink_v3_ns.xsd
@@ -491,7 +491,7 @@
             <xs:attributeGroup ref="manialink:basicAttrib" />
             <xs:attribute name="size" type="manialink:type_float2positive" use="optional" />
             <xs:attribute name="clip" type="manialink:type_bool" use="optional" />
-            <xs:attribute name="clipposn" type="manialink:type_float2positive" use="optional" />
+            <xs:attribute name="clipposn" type="manialink:type_float2" use="optional" />
             <xs:attribute name="clipsizen" type="manialink:type_float2positive" use="optional" />
             <xs:attribute name="scroll" type="manialink:type_bool" use="optional" />
             <xs:attribute name="scrollmax" type="manialink:type_float2positive" use="optional" />


### PR DESCRIPTION
This is a small issue I found in one of my older manialinks. `clipposn` is valid when used with negative float values.